### PR TITLE
Redux에서 여러차례 연속적으로 상태조작할 경우 성능 저하 발생하는 이슈 해결

### DIFF
--- a/src/main/pages/Home/CategoryList/index.jsx
+++ b/src/main/pages/Home/CategoryList/index.jsx
@@ -32,6 +32,7 @@ function CategoryList() {
 
   const draggedCategoryRef = useRef(null)
   const [linkHoverTabId, setLinkHoverTabId] = useState(null)
+  const [dragOverTabData, setDragOverTabData] = useState({})
 
   const handleDragOverFirstFavorite = useCallback(
     (e) => {
@@ -87,16 +88,11 @@ function CategoryList() {
       if (dragType === LINK) {
         if (tagetCategoryData.id !== linkHoverTabId) setLinkHoverTabId(tagetCategoryData.id)
       } else if (dragType === CATEGORY) {
-        const order = dragData.order < tagetCategoryData.order ? tagetCategoryData.order - 1 : tagetCategoryData.order
-        setDragData({
-          ...dragData,
-          order,
-          is_favorited: tagetCategoryData.is_favorited,
-        })
+        setDragOverTabData({ ...dragOverTabData, ...tagetCategoryData })
         dragLineRef.current.style.opacity = 1
       }
     },
-    [dragData, dragType, linkHoverTabId, setDragData]
+    [dragType, linkHoverTabId, dragOverTabData, setDragOverTabData]
   )
 
   const handleDragLeave = useCallback(
@@ -118,12 +114,13 @@ function CategoryList() {
       try {
         if (dragType === CATEGORY) {
           if (dragLineRef) dragLineRef.current.style.opacity = 0
+
           await dispatch(
             categoryModifyThunk({
               id: dragData.id,
               name: dragData.name,
-              order: dragData.order,
-              is_favorited: dragData.is_favorited,
+              order: dragData.order < dragOverTabData.order ? dragOverTabData.order - 1 : dragOverTabData.order,
+              is_favorited: dragOverTabData.is_favorited,
             })
           )
           await dispatch(categoriesReadThunk())
@@ -152,6 +149,7 @@ function CategoryList() {
       linkListData,
       linkHoverTabId,
       selectedCategory?.id,
+      dragOverTabData,
       clearDragData,
       openToast,
     ]


### PR DESCRIPTION
- dragOver 함수 내에서 reducer 함수 호출 대신 useState 로 상태 관리하는 것으로 로직 변경