### PR TITLE
카테고리 스타일 변경

### DIFF
--- a/src/assets/css/default.css
+++ b/src/assets/css/default.css
@@ -1,13 +1,14 @@
 :root {
   --maincolor: #2083ff;
   --lightblue: #77caff;
-  --powder-blue: #afe7ff;
+  --powder-blue: #e3f0ff;
   --pale-sky-blue: #c2e8ff;
   --maintext: #212529;
   --battleship-grey: #737b84;
   --blue-grey: #868e96;
   --very-light-blue: #e9ecef;
-  --pale-grey: #f6f7f9;
+  --pale-grey: #c4c4c4;
+  --light-grey: #f4f4f4;
   --salmon: #ff6b6b;
   --green-blue: #00b381;
 }

--- a/src/assets/css/popup.css
+++ b/src/assets/css/popup.css
@@ -15,7 +15,7 @@ body {
 .popup-body {
   position: relative;
   width: 260px;
-  height: 410px;
+  height: 430px;
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.15), 0 5px 12px 0 rgba(0, 0, 0, 0.12);
   background-color: #ffffff;
 }
@@ -209,10 +209,9 @@ body {
 
   margin: 17px;
   width: 228px;
-  height: 40px;
-  border-radius: 1.8px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1), 0 1px 5px 0 rgba(0, 0, 0, 0.1);
-  background-color: var(--blue-grey);
+  height: 48px;
+  border-radius: 4px;
+  background-color: var(--light-grey);
 }
 
 /* .link-save-btn .link-save-btn-text{
@@ -235,13 +234,8 @@ body {
   align-items: center;
   justify-content: center;
 
-  margin: 17px;
-  width: 228px;
-  height: 40px;
-  border-radius: 1.8px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1), 0 1px 5px 0 rgba(0, 0, 0, 0.1);
-  background-color: #ffffff;
-  color: var(--maintext);
+  background-color: var(--maincolor);
+  color: #fff;
 }
 
 /* urlLink open */
@@ -252,17 +246,16 @@ body {
 
   margin: 17px;
   width: 228px;
-  height: 40px;
-  border-radius: 1.8px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1), 0 1px 5px 0 rgba(0, 0, 0, 0.1);
-  background-color: var(--maincolor);
+  height: 48px;
+  border-radius: 4px;
+  background-color: var(--powder-blue);
 }
 
 .urlLink-open-btn .urlLink-open-btn-text {
   padding: 14px;
   width: 100%;
   height: 20px;
-  color: #ffffff;
+  color: var(--maincolor);
 }
 
 a.urlLink-open-btn-text:link {

--- a/src/main/pages/Home/CategoryList/CategoryButtonGroup/index.jsx
+++ b/src/main/pages/Home/CategoryList/CategoryButtonGroup/index.jsx
@@ -64,10 +64,7 @@ function CategoryButtonGroup() {
   )
 
   const handleChangeNewCategoryTitle = useCallback((e) => {
-    const checks = /[a-zA-Z]/
-    if (checks.test(e.target.value)) {
-      if (e.target.value.length >= 14) return
-    } else if (e.target.value.length >= 7) return
+    if (e.target.value.length > 18) return
     setCategoryName(e.target.value)
   }, [])
 

--- a/src/main/pages/Home/CategoryList/CategoryItem/index.jsx
+++ b/src/main/pages/Home/CategoryList/CategoryItem/index.jsx
@@ -42,17 +42,14 @@ function CategoryItem({ data = {}, selected = false, hovered = false, dragFinish
           <div
             className={clsx(classes.title, {
               [classes.selectedTitle]: Boolean(selected),
+              [classes.favoriteTitle]: Boolean(data.is_favorited),
             })}
           >
             {isEditingTitle ? editedCategory?.name : data?.name}
           </div>
 
           <div className={classes.linkBox}>
-            <span
-              className={clsx(classes.urlCountBox, {
-                [classes.marginRight]: !Boolean(data.is_favorited),
-              })}
-            >
+            <span className={clsx(classes.urlCountBox)}>
               {data.url_count === 0 ? '링크 없음' : data.url_count + ' 링크'}
             </span>
             {data.is_favorited && (

--- a/src/main/pages/Home/CategoryList/CategoryItem/style.js
+++ b/src/main/pages/Home/CategoryList/CategoryItem/style.js
@@ -6,6 +6,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
+    padding: '18px 16px',
   },
 
   listTab: {
@@ -22,16 +23,19 @@ const useStyles = makeStyles((theme) => ({
     outline: 'none',
   },
   title: {
-    fontSize: 16,
-    maxWidth: '60%',
+    fontSize: 14,
+    width: 120,
     color: '#212529',
-    padding: 18,
-    height: 58,
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
   },
   selectedTitle: {
     color: '#2083ff',
     fontWeight: 'bold',
-    maxWidth: '65%',
+  },
+  favoriteTitle: {
+    width: '60%',
   },
   hoveredItem: {
     backgroundColor: 'rgba(32, 131, 255, 0.1)',
@@ -54,7 +58,7 @@ const useStyles = makeStyles((theme) => ({
     textAlign: 'center',
   },
   favoriteStar: {
-    marginRight: '8px',
+    marginLeft: '2px',
   },
   block: {
     display: 'block',
@@ -62,13 +66,10 @@ const useStyles = makeStyles((theme) => ({
   hidden: {
     display: 'none',
   },
-  marginRight: {
-    marginRight: '8px',
-  },
   linkBox: {
     display: 'flex',
     alignItems: 'center',
-    maxWidth: '40%',
+    justifyContent: 'flex-end',
   },
   dragFinished: {
     position: 'relative',

--- a/src/main/pages/Home/LinkList/Header/EditableCategoryTitle/index.jsx
+++ b/src/main/pages/Home/LinkList/Header/EditableCategoryTitle/index.jsx
@@ -24,11 +24,9 @@ import { isObjkeysEmpty } from '@utils/filter'
 
 import useStyles from './style'
 
-const CHECK_CATEGORY_NAME = /[a-zA-Z]/
-const CATEGORY_NAME_EN_MAX_LENTH = 13
-const CATEGORY_NAME_KO_MAX_LENTH = 6
+const CATEGORY_NAME_MAX_LENTH = 18
 const CATEGORY_SCHEMA = yup.object({
-  name: yup.string().max(CATEGORY_NAME_EN_MAX_LENTH).required(),
+  name: yup.string().max(CATEGORY_NAME_MAX_LENTH).required(),
 })
 
 function EditableCategoryTitle() {
@@ -45,15 +43,11 @@ function EditableCategoryTitle() {
   })
 
   const rootRef = useRef(null)
-  const [categoryNameMaxLength, setCategoyNameMaxLength] = useState(CATEGORY_NAME_EN_MAX_LENTH)
   const [isEditable, setIsEditable] = useState(false)
 
   const editedName = watch('name') || ''
 
   useEffect(() => {
-    if (CHECK_CATEGORY_NAME.test(editedName)) setCategoyNameMaxLength(CATEGORY_NAME_EN_MAX_LENTH)
-    else setCategoyNameMaxLength(CATEGORY_NAME_KO_MAX_LENTH)
-
     if (isEditable) dispatch(categoryEdit({ name: editedName }))
   }, [isEditable, editedName, dispatch])
 
@@ -106,7 +100,7 @@ function EditableCategoryTitle() {
             onKeyUp={handleEditKeyUp}
             autoFocus
             inputProps={{
-              maxLength: categoryNameMaxLength,
+              maxLength: CATEGORY_NAME_MAX_LENTH,
             }}
             inputRef={register}
           />


### PR DESCRIPTION
### 카테고리 타이틑 글자 수가 늘어날때 스타일 깨지는 이슈

- 카테고리 폰트 16pt 에서 14pt로 변경
- 카테고리 타이틀 width 120px 초과 시 `textOverflow: 'ellipsis'` 적용
- 한/영 혼용 최대 18자 입력 가능하도록 수정

### 크롬 익스텐션 팝업 스타일 수정
- 버튼 스타일 수정 
