### PR TITLE
버그픽스 : 카테고리 리스트에서 카테고리가 없을때 스크롤 되는 버그 수정

### DIFF
--- a/src/main/pages/Home/CategoryList/FirstCategoryDropZone/style.js
+++ b/src/main/pages/Home/CategoryList/FirstCategoryDropZone/style.js
@@ -6,7 +6,7 @@ const useStyles = makeStyles((theme) => ({
   },
   categoryDropZone: {
     width: '212px',
-    height: '100vh',
+    height: '70%',
   },
 }))
 


### PR DESCRIPTION
## 일반 카테고리가 하나도 없을 때 FirstCategoryDropZone 컴포넌트가 height 100%로 적용되어 스크롤 되는 이슈

* 현재 Favorite 카테고리가 1개일 경우의 height만 대략적으로 계산해서 70%로 수정해놓은 상태

### 추후 개선 필요 

현재로서는 Favorite 카테고리의 길이를 빼서 FirstCategoryDropZone의 길이를 구해서 대입하려면 useRef를 사용해야할 것 같습니다. 개인적으로 그것보다는 이번에는 이렇게만 수정하고, 다음 배포때 CategoryList 안의 요소들을 아래의 방안으로 수정해서 개선해야할 것 같습니다.

1. material-ui 버전업 시키면 있는 Stack이라는 컴포넌트를 사용하여 CategoryList 컴포넌트 내부 구조를 수정해서 반영
2. CategoryList 내부를 display: flex를 활용해서 수정