### PR TITLE
LinkList 컴포넌트에 이미지가 중복으로 렌더링 되는 이슈 해결 및 LinkList 컴포넌트의 헤더 관련 조건 추가

### DIFF
--- a/src/main/pages/Home/LinkList/index.jsx
+++ b/src/main/pages/Home/LinkList/index.jsx
@@ -87,8 +87,6 @@ function LinkList() {
     }
   }, [dragData, linkCreatePending, linksReadPending])
 
-  console.log(categoryList, selectedLinkList)
-
   return (
     <Grid container direction="column" className={classes.root} ref={rootRef}>
       {!!categoryList.length && !!links.length && (
@@ -115,7 +113,7 @@ function LinkList() {
             <img src={CategoryEmptyImg} alt="카테고리 비어 있음" />
           </Grid>
         ) : (
-          links?.length === LINK_EMPTY &&
+          links.length === LINK_EMPTY &&
           (skeletonLength ? null : searchFilter.keyword && SEARCH_LINK_EMPTY ? (
             <Grid item xs={12} className={classes.center}>
               <img src={linkListSearchEmptyImg} alt="검색 조회 없음" />


### PR DESCRIPTION
# Issue

- [참고](https://www.notion.so/worldwidegw/QA-0-ff5f78bbdc02427bb5b9da61aca9da17#fcfcc39d68474617bd49ed491c6f6042)
- LinkList 컴포넌트에 '카테고리 비어 있음'을 의미하는 이미지와 '링크 비어 있음'을 의미하는 이미지가 중복으로 렌더링 되는 현상

# Sol
- 카테고리가 하나도 없는 경우의 조건과 카테고리에 링크가 하나도 없는 경우의 조건을 함께 분기 처리하여 중복으로 이미지가 렌더링되지 않도록 처리

---

# Issue
- 카테고리와 링크 갯수가 0개 일 때 헤더가 보여지는 현상

# Sol
- 카테고리와 링크 갯수가 0개 일 때는 헤더 숨김 처리