### PR TITLE
카테고리가 하나도 없는 상태에서 방문기록 드래그 드랍할 때 에러 메세지 추가

### DIFF
--- a/src/main/pages/Home/LinkDropZone/index.jsx
+++ b/src/main/pages/Home/LinkDropZone/index.jsx
@@ -27,6 +27,10 @@ function LinkDropZone() {
     async (e) => {
       try {
         e.stopPropagation()
+        if (!categoryList.length) {
+          openToast({ type: 'error', message: '카테고리를 생성해주세요.' })
+          return
+        }
         const path = listData.reduce((prev, data) => prev.concat(data.path), [])
         await dispatch(linkCreateThunk({ categoryId: selectedCategory.id, path }))
         clearDragData()
@@ -34,14 +38,10 @@ function LinkDropZone() {
         dispatch(categoriesRead.request())
         openToast({ type: 'success', message: '링크가 저장 되었습니다.' })
       } catch (error) {
-        if (!categoryList.length) {
-          openToast({ type: 'error', message: '카테고리를 생성해주세요.' })
-        } else {
-          openToast({ type: 'error', message: error?.response?.data?.message || '네트워크 오류!!' })
-        }
+        openToast({ type: 'error', message: error?.response?.data?.message || '네트워크 오류!!' })
       }
     },
-    [dispatch, listData, openToast, selectedCategory.id, clearDragData]
+    [dispatch, listData, openToast, selectedCategory.id, clearDragData, categoryList]
   )
 
   const handleDragOverOnCardArea = useCallback((e) => {


### PR DESCRIPTION
# Issue
- 카테고리가 하나도 없는 상태에서 방문기록을 드래그 드랍 하면 '네트워크 오류' 에러 메세지의 토스트가 팝업되는 현상

# Sol
- 카테고리가 없을 경우의 에러 조건을 추가하여 '카테고리를 생성해주세요.' 에러 메세지의 토스트가 팝업되도록 수정