### PR TITLE
구글 OAuth 요청 모달에서 중도 닫을 때도 api 요청 현상 발생

### DIFF
--- a/src/utils/chromeApis/OAuth.js
+++ b/src/utils/chromeApis/OAuth.js
@@ -2,7 +2,11 @@ export function getAuthToken() {
   return new Promise((resolve, reject) => {
     const idCheck = chrome.runtime?.id
     if (!idCheck) reject({ message: 'is not defined getAuthToken' })
-    else chrome.identity.getAuthToken({ interactive: true }, (token) => resolve(token))
+    else {
+      chrome.identity.getAuthToken({ interactive: true }, (token) => {
+        if (token) resolve(token)
+      })
+    }
   })
 }
 


### PR DESCRIPTION
# Issue

구글 OAuth 요청 모달에서 중도 닫을 때도 api 요청 현상 발생 하여, 사용자에서 오류로 인식 하는 이슈

# Sol

- 구글 OAuth 토큰을 못받을 때, resolve 호출 안하도록 조건문 설정